### PR TITLE
feat: more flexible response checking; support `wait_until: None`

### DIFF
--- a/cmd/src/account.rs
+++ b/cmd/src/account.rs
@@ -7,7 +7,7 @@ use log::info;
 use near_crypto::{InMemorySigner, KeyType, SecretKey};
 use near_jsonrpc_client::JsonRpcClient;
 use near_ops::block_service::BlockService;
-use near_ops::rpc_response_handler::RpcResponseHandler;
+use near_ops::rpc_response_handler::{ResponseCheckSeverity, RpcResponseHandler};
 use near_ops::{
     account::{new_create_subaccount_actions, Account},
     rpc::{new_request, view_access_key},
@@ -68,8 +68,12 @@ pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result
     let wait_until_channel = wait_until.clone();
     let num_expected_responses = args.num_sub_accounts;
     let response_handler_task = tokio::task::spawn(async move {
-        let mut rpc_response_handler =
-            RpcResponseHandler::new(channel_rx, wait_until_channel, num_expected_responses);
+        let mut rpc_response_handler = RpcResponseHandler::new(
+            channel_rx,
+            wait_until_channel,
+            ResponseCheckSeverity::Assert,
+            num_expected_responses,
+        );
         rpc_response_handler.handle_all_responses().await;
     });
 

--- a/cmd/src/account.rs
+++ b/cmd/src/account.rs
@@ -12,6 +12,7 @@ use near_ops::{
     account::{new_create_subaccount_actions, Account},
     rpc::{new_request, view_access_key},
 };
+use near_primitives::views::TxExecutionStatus;
 use near_primitives::{
     transaction::{Transaction, TransactionV0},
     types::AccountId,
@@ -63,9 +64,12 @@ pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result
     // TODO find reasonable buffer size.
     let (channel_tx, channel_rx) = mpsc::channel(1200);
 
+    let wait_until = TxExecutionStatus::ExecutedOptimistic;
+    let wait_until_channel = wait_until.clone();
     let num_expected_responses = args.num_sub_accounts;
     let response_handler_task = tokio::task::spawn(async move {
-        let mut rpc_response_handler = RpcResponseHandler::new(channel_rx, num_expected_responses);
+        let mut rpc_response_handler =
+            RpcResponseHandler::new(channel_rx, wait_until_channel, num_expected_responses);
         rpc_response_handler.handle_all_responses().await;
     });
 
@@ -83,7 +87,7 @@ pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result
                 args.deposit,
             ),
         });
-        let request = new_request(tx, signer.clone());
+        let request = new_request(tx, wait_until.clone(), signer.clone());
 
         interval.tick().await;
         let client = client.clone();

--- a/near_ops/src/rpc.rs
+++ b/near_ops/src/rpc.rs
@@ -16,10 +16,14 @@ use near_primitives::{
     },
 };
 
-pub fn new_request(transaction: Transaction, signer: InMemorySigner) -> RpcSendTransactionRequest {
+pub fn new_request(
+    transaction: Transaction,
+    wait_until: TxExecutionStatus,
+    signer: InMemorySigner,
+) -> RpcSendTransactionRequest {
     RpcSendTransactionRequest {
         signed_transaction: transaction.sign(&Signer::from(signer)),
-        wait_until: TxExecutionStatus::ExecutedOptimistic,
+        wait_until,
     }
 }
 

--- a/near_ops/src/rpc_response_handler.rs
+++ b/near_ops/src/rpc_response_handler.rs
@@ -5,6 +5,7 @@ use near_jsonrpc_client::{
     errors::JsonRpcError,
     methods::tx::{RpcTransactionError, RpcTransactionResponse},
 };
+use near_primitives::views::TxExecutionStatus;
 use tokio::sync::mpsc::Receiver;
 
 use crate::rpc::assert_transaction_and_receipts_success;
@@ -13,13 +14,20 @@ pub type RpcCallResult = Result<RpcTransactionResponse, JsonRpcError<RpcTransact
 
 pub struct RpcResponseHandler {
     receiver: Receiver<RpcCallResult>,
+    /// The `wait_until` value of the transactions whose responses are awaited.
+    wait_until: TxExecutionStatus,
     num_expected_responses: u64,
 }
 
 impl RpcResponseHandler {
-    pub fn new(receiver: Receiver<RpcCallResult>, num_expected_responses: u64) -> Self {
+    pub fn new(
+        receiver: Receiver<RpcCallResult>,
+        wait_until: TxExecutionStatus,
+        num_expected_responses: u64,
+    ) -> Self {
         Self {
             receiver,
+            wait_until,
             num_expected_responses,
         }
     }


### PR DESCRIPTION
- More flexible response checking which makes supporting different `wait_until` values easier.
- Add support for `wait_until: NONE`.
- Enable toggling warning or panic on unexpected responses.