### PR TITLE
refactor: add CLI args

### DIFF
--- a/cmd/src/account.rs
+++ b/cmd/src/account.rs
@@ -48,6 +48,9 @@ pub struct CreateSubAccountsArgs {
     /// Amount to deposit with each sub-account.
     #[arg(long)]
     pub deposit: u128,
+    #[arg(long)]
+    /// Acts as upper bound on the number of concurrently open RPC requests.
+    pub channel_buffer_size: usize,
     /// After each tick (in microseconds) a transaction is sent. If the hardware cannot keep up with
     /// that or if the NEAR node is congested, transactions are sent at a slower rate.
     #[arg(long)]
@@ -73,7 +76,7 @@ pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result
     // Before a request is made, a permit to send into the channel is awaited. Hence buffer size
     // limits the number of outstanding requests. This helps to avoid congestion.
     // TODO find reasonable buffer size.
-    let (channel_tx, channel_rx) = mpsc::channel(1200);
+    let (channel_tx, channel_rx) = mpsc::channel(args.channel_buffer_size);
 
     let wait_until = TxExecutionStatus::ExecutedOptimistic;
     let wait_until_channel = wait_until.clone();

--- a/cmd/src/account.rs
+++ b/cmd/src/account.rs
@@ -31,6 +31,17 @@ pub struct CreateSubAccountsArgs {
     // TODO remove this field and get nonce from rpc
     #[arg(long, default_value_t = 1)]
     pub nonce: u64,
+    /// Optional prefix for sub account names to avoid generating accounts that already exist on
+    /// subsequent invocations.
+    ///
+    /// # Example
+    ///
+    /// The name of the `i`-th sub account will be:
+    ///
+    /// - `user_<i>.<signer_account_id>` if `sub_account_prefix == None`
+    /// - `a_user_<i>.<signer_account_id>` if `sub_account_prefix == Some("a")`
+    #[arg(long)]
+    pub sub_account_prefix: Option<String>,
     /// Number of sub accounts to create.
     #[arg(long)]
     pub num_sub_accounts: u64,
@@ -79,7 +90,14 @@ pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result
 
     for i in 0..args.num_sub_accounts {
         let sub_account_key = SecretKey::from_random(KeyType::ED25519);
-        let sub_account_id: AccountId = format!("user_{i}_a2.{}", signer.account_id).parse()?;
+        let sub_account_id: AccountId = {
+            let subname = if let Some(prefix) = &args.sub_account_prefix {
+                format!("{prefix}_user_{i}")
+            } else {
+                format!("user_{i}")
+            };
+            format!("{subname}.{}", signer.account_id).parse()?
+        };
         let tx = Transaction::V0(TransactionV0 {
             signer_id: signer.account_id.clone(),
             public_key: signer.public_key().clone(),

--- a/cmd/src/benchmark.rs
+++ b/cmd/src/benchmark.rs
@@ -25,6 +25,7 @@ pub struct BenchmarkNativeTransferArgs {
     #[arg(long)]
     pub num_transfers: u64,
     /// Acts as upper bound on the number of concurrently open RPC requests.
+    #[arg(long)]
     pub channel_buffer_size: usize,
     /// After each tick (in microseconds) a transaction is sent. If the hardware cannot keep up with
     /// that or if the NEAR node is congested, transactions are sent at a slower rate.

--- a/cmd/src/benchmark.rs
+++ b/cmd/src/benchmark.rs
@@ -24,6 +24,8 @@ pub struct BenchmarkNativeTransferArgs {
     pub user_data_dir: PathBuf,
     #[arg(long)]
     pub num_transfers: u64,
+    /// Acts as upper bound on the number of concurrently open RPC requests.
+    pub channel_buffer_size: usize,
     /// After each tick (in microseconds) a transaction is sent. If the hardware cannot keep up with
     /// that or if the NEAR node is congested, transactions are sent at a slower rate.
     #[arg(long)]
@@ -49,7 +51,7 @@ pub async fn benchmark_native_transfers(args: &BenchmarkNativeTransferArgs) -> a
     // Before a request is made, a permit to send into the channel is awaited. Hence buffer size
     // limits the number of outstanding requests. This helps to avoid congestion.
     // TODO find reasonable buffer size.
-    let (channel_tx, channel_rx) = mpsc::channel(3500);
+    let (channel_tx, channel_rx) = mpsc::channel(args.channel_buffer_size);
 
     let wait_until = TxExecutionStatus::None;
     let wait_until_channel = wait_until.clone();

--- a/justfile
+++ b/justfile
@@ -63,8 +63,9 @@ bmnf:
     cargo run -p cmd --release -- benchmark-native-transfers \
         --rpc-url {{rpc_url}} \
         --user-data-dir user-data/ \
-        --num-transfers 20000 \
-        --interval-duration-micros 400 \
+        --num-transfers 500000 \
+        --channel-buffer-size 2500 \
+        --interval-duration-micros 200 \
         --amount 1
 
 view_account id:
@@ -88,3 +89,10 @@ view_protocol_config:
       params:='{ \
         "finality": "final" \
       }'
+
+send_dummy_tx wait_until:
+    http post {{rpc_url}} jsonrpc=2.0 id=dontcare method=send_tx \
+        params:='{ \
+          "signed_tx_base64": "DgAAAHNlbmRlci50ZXN0bmV0AOrmAai64SZOv9e/naX4W15pJx0GAap35wTT1T/DwcbbDwAAAAAAAAAQAAAAcmVjZWl2ZXIudGVzdG5ldNMnL7URB1cxPOu3G8jTqlEwlcasagIbKlAJlF5ywVFLAQAAAAMAAACh7czOG8LTAAAAAAAAAGQcOG03xVSFQFjoagOb4NBBqWhERnnz45LY4+52JgZhm1iQKz7qAdPByrGFDQhQ2Mfga8RlbysuQ8D8LlA6bQE=", \
+          "wait_until": "{{wait_until}}" \
+        }'

--- a/justfile
+++ b/justfile
@@ -26,8 +26,10 @@ csa:
         --rpc-url {{rpc_url}} \
         --signer-key-path {{near_localnet_home}}/validator_key.json \
         --nonce 1 \
+        --sub-account-prefix 'a' \
         --num-sub-accounts 10000 \
         --deposit 953060601875000000010000 \
+        --channel-buffer-size 1200 \
         --interval-duration-micros 1500 \
         --user-data-dir user-data
 


### PR DESCRIPTION
These parameters where previously hardcoded but require frequent changes, which is easier when they are CLI args.